### PR TITLE
Fix incombatibility with Better Multishot

### DIFF
--- a/src/main/java/com/dplayend/ite/api/TridentThrowListener.java
+++ b/src/main/java/com/dplayend/ite/api/TridentThrowListener.java
@@ -1,0 +1,11 @@
+package com.dplayend.ite.api;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.ItemStack;
+
+@FunctionalInterface
+public interface TridentThrowListener {
+
+    void accept(TridentEntity thrownTrident, ItemStack tridentItem, PlayerEntity user, float pitch, float yaw, float roll, float speed, float divergence);
+}

--- a/src/main/java/com/dplayend/ite/api/TridentThrowListenerRegistry.java
+++ b/src/main/java/com/dplayend/ite/api/TridentThrowListenerRegistry.java
@@ -1,0 +1,12 @@
+package com.dplayend.ite.api;
+
+import com.dplayend.ite.impl.TridentThrowListenerRegistryImpl;
+
+import java.util.List;
+
+public interface TridentThrowListenerRegistry {
+    TridentThrowListenerRegistry INSTANCE  = new TridentThrowListenerRegistryImpl();
+
+    void registerListener(TridentThrowListener listener);
+    List<TridentThrowListener> getListeners();
+}

--- a/src/main/java/com/dplayend/ite/impl/TridentThrowListenerRegistryImpl.java
+++ b/src/main/java/com/dplayend/ite/impl/TridentThrowListenerRegistryImpl.java
@@ -1,0 +1,21 @@
+package com.dplayend.ite.impl;
+
+import com.dplayend.ite.api.TridentThrowListener;
+import com.dplayend.ite.api.TridentThrowListenerRegistry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TridentThrowListenerRegistryImpl implements TridentThrowListenerRegistry {
+    public final List<TridentThrowListener> listeners = new ArrayList<>();
+
+    @Override
+    public void registerListener(TridentThrowListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public List<TridentThrowListener> getListeners() {
+        return listeners;
+    }
+}

--- a/src/main/java/com/dplayend/ite/mixin/MixTridentItem.java
+++ b/src/main/java/com/dplayend/ite/mixin/MixTridentItem.java
@@ -1,5 +1,6 @@
 package com.dplayend.ite.mixin;
 
+import com.dplayend.ite.api.TridentThrowListenerRegistry;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.LivingEntity;
@@ -97,13 +98,22 @@ public class MixTridentItem {
     }
 
     @Unique private void createTrident(ItemStack stack, World world, PlayerEntity playerEntity) {
+        float pitch = playerEntity.getPitch();
+        float yaw = playerEntity.getYaw();
+        float roll = 0;
+        float speed = 2.5f;
+        float divergence = 1.0f;
+
         TridentEntity tridentEntity = new TridentEntity(world, playerEntity, stack);
-        tridentEntity.setVelocity(playerEntity, playerEntity.getPitch(), playerEntity.getYaw(), 0.0F, 2.5F, 1.0F);
+        tridentEntity.setVelocity(playerEntity, pitch, yaw, roll, speed, divergence);
         if (playerEntity.getAbilities().creativeMode) {
             tridentEntity.pickupType = PersistentProjectileEntity.PickupPermission.CREATIVE_ONLY;
         }
 
         world.spawnEntity(tridentEntity);
+
+        TridentThrowListenerRegistry.INSTANCE.getListeners().forEach(listener -> listener.accept(tridentEntity, stack, playerEntity, pitch, yaw, roll, speed, divergence));
+
         world.playSoundFromEntity(null, tridentEntity, SoundEvents.ITEM_TRIDENT_THROW, SoundCategory.PLAYERS, 1.0F, 1.0F);
         if (!playerEntity.getAbilities().creativeMode) {
             playerEntity.getInventory().removeOne(stack);


### PR DESCRIPTION
I am the developer of [Better Multishot](https://modrinth.com/mod/bettermultishot), and it has come to my attention that, because this mod entirely replaces vanilla code, multishot doesn't work on tridents when this mod is installed.
I have done some digging and have a few ideas to fix this.
The first idea is to rewrite this mod to modify vanilla code instead of replacing it. While that could work, it would probably make the code a lot harder to read and maintain, as there would need to be a ton of mixins into the same method.
The other idea (this PR) is to add an API that allows me to add custom behavior when this mod shoots its trident.

Please do have a look through my code, as it's probably a bit rough on the edges.